### PR TITLE
Mobile: boost the hero portrait (anchored top-right, half-bleed)

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -137,6 +137,15 @@ const typedLines = [
     letter-spacing: 0.06em;
   }
 
+  /* Mobile: drop the hero text to the bottom so the boosted portrait owns the
+     top-right of the screen (see PortraitField.astro mobile treatment). */
+  @media (max-width: 860px) {
+    .inner {
+      align-items: flex-end;
+      padding-bottom: 12vh;
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .btn.primary:hover {
       transform: none;

--- a/src/components/PortraitField.astro
+++ b/src/components/PortraitField.astro
@@ -49,21 +49,27 @@ const { src = '/portrait-field.jpg', class: className = '' } = Astro.props;
       transparent 86%
     );
   }
+  /* Mobile: a large square portrait in the upper area, offset off the right
+     edge so ~half the face bleeds away — boosted and clearly visible, with the
+     hero text dropped to the bottom (see Hero.astro) so they don't overlap. */
   @media (max-width: 860px) {
     .portrait-canvas {
-      width: 100%;
-      opacity: 0.5;
+      width: 112vw;
+      height: 112vw;
+      top: 2vh;
+      right: -34vw;
+      opacity: 0.95;
       -webkit-mask-image: radial-gradient(
-        70% 55% at 60% 30%,
+        54% 54% at 46% 44%,
         #000 0%,
-        #000 42%,
-        transparent 82%
+        #000 50%,
+        transparent 80%
       );
       mask-image: radial-gradient(
-        70% 55% at 60% 30%,
+        54% 54% at 46% 44%,
         #000 0%,
-        #000 42%,
-        transparent 82%
+        #000 50%,
+        transparent 80%
       );
     }
   }


### PR DESCRIPTION
Improves the mobile hero: the portrait was a faint full-width texture; it's now a large, boosted point-field face in the upper area, offset off the right edge so ~half bleeds away (mirroring the desktop treatment), with the hero text dropped to the bottom so they don't overlap.

Scoped entirely to `@media (max-width: 860px)` — desktop is unchanged. Verified in a 390px phone frame across home, work, contact, about + the mobile menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)