### PR TITLE
Mobile: put the hero text above the portrait

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -137,12 +137,11 @@ const typedLines = [
     letter-spacing: 0.06em;
   }
 
-  /* Mobile: drop the hero text to the bottom so the boosted portrait owns the
-     top-right of the screen (see PortraitField.astro mobile treatment). */
+  /* Mobile: text sits at the top; the boosted portrait sits below it, anchored
+     to the lower-right (see PortraitField.astro mobile treatment). */
   @media (max-width: 860px) {
     .inner {
-      align-items: flex-end;
-      padding-bottom: 12vh;
+      align-items: flex-start;
     }
   }
 

--- a/src/components/PortraitField.astro
+++ b/src/components/PortraitField.astro
@@ -56,7 +56,8 @@ const { src = '/portrait-field.jpg', class: className = '' } = Astro.props;
     .portrait-canvas {
       width: 112vw;
       height: 112vw;
-      top: 2vh;
+      top: auto;
+      bottom: -4vh;
       right: -34vw;
       opacity: 0.95;
       -webkit-mask-image: radial-gradient(


### PR DESCRIPTION
Flips the mobile hero order per feedback: text at the top, the boosted point-field portrait anchored below it (lower-right, half-bleed). Scoped to max-width: 860px; desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)