### PR TITLE
Nav: make the full wordmark bold

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -190,8 +190,8 @@ const socials = [
     font-weight: 700;
   }
   .wordmark__last {
-    color: var(--muted);
-    font-weight: 400;
+    color: var(--text);
+    font-weight: 700;
   }
 
   .site-nav__links {


### PR DESCRIPTION
The last name (jusic) was muted gray + regular weight and receded; set it to the same bold white as patrick so the full name reads clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)